### PR TITLE
Fix A* to go through the door + Fix empty path in npc to prevent crash

### DIFF
--- a/MyBotLogic/MyBotLogic.cpp
+++ b/MyBotLogic/MyBotLogic.cpp
@@ -35,7 +35,7 @@ MyBotLogic::MyBotLogic()
     //Write Code Here
 }
 
-/*virtual*/ void MyBotLogic::Load()
+/*virtual*/ void MyBotLogic::Start()
 {
     //Write Code Here
 #ifdef BOT_LOGIC_DEBUG
@@ -57,11 +57,6 @@ MyBotLogic::MyBotLogic()
     BOT_LOGIC_LOG(mLogger, "NPCs Initialisation", true);
     NPCManager::get()->initNpcs(_levelInfo.npcs);
 
-}
-
-/*virtual*/ void MyBotLogic::OnBotInitialized()
-{
-    //Write Code Here
 }
 
 /*virtual*/ void MyBotLogic::OnGameStarted()

--- a/MyBotLogic/MyBotLogic.h
+++ b/MyBotLogic/MyBotLogic.h
@@ -28,8 +28,7 @@ public:
 	virtual ~MyBotLogic();
 
 	virtual void Configure(int argc, char *argv[], const std::string& _logpath);
-	virtual void Load();
-	virtual void OnBotInitialized();
+	virtual void Start();
 	virtual void Init(LevelInfo& _levelInfo);
 	virtual void OnGameStarted();
 	virtual void FillActionList(TurnInfo& _turnInfo, std::vector<Action*>& _actionList);   //calculate moves for a single turn

--- a/MyBotLogic/Node.h
+++ b/MyBotLogic/Node.h
@@ -95,7 +95,15 @@ public:
 
     bool isEdgeBlocked(EDirection dir) const
     {
-        return m_edgesCost[dir] == 0 ? false : true;
+        switch(m_edgesCost[dir])
+        {
+            case 0: //No wall or anything blocking (default state)
+            case ObjectType_Door + 1: // Add +1 because of the default state which is 0 and HighWall is 0 to, so we save the edges with +1
+                return false;
+            default:
+                return true;
+
+        }
     }
 
     void setNeighboor(EDirection dir, Node* p)

--- a/MyBotLogic/Npc.cpp
+++ b/MyBotLogic/Npc.cpp
@@ -114,7 +114,13 @@ void Npc::calculPath()
     {
         return;
     }
-    m_path = Map::get()->getNpcPath(getCurrentTileId(), m_goal);
+    std::vector<unsigned> path = Map::get()->getNpcPath(getCurrentTileId(), m_goal);
+    if(path.size() <= 0)
+    {
+        m_hasGoal = false;
+        return;
+    }
+    m_path = path;
 }
 
 bool Npc::updatePath()


### PR DESCRIPTION
Fix du A* qui permet maintenant de passer au travers des portes (pour faire fonctionner la map TC_050 et TC_051). Attention tout de même ce n'est pas forcément tout le temps le cas et cela peut générer des bugs par la suite, il faut faire attention.

Fix du path dans le NPC pour éviter de set un path null et ne plus avoir de crash